### PR TITLE
fix: unit test logs

### DIFF
--- a/internal/infrastructure/logger/gorm_log_test.go
+++ b/internal/infrastructure/logger/gorm_log_test.go
@@ -33,7 +33,11 @@ const (
 )
 
 // https://regex101.com/
-const regularExp = `^time=[[:digit:]]{4}\-[[:digit:]]{2}\-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg=(.*)\n$`
+const (
+	timeExp    = `time=[[:digit:]]{4}\-[[:digit:]]{2}\-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]+(|Z|\+[[:digit:]]{2}:[[:digit:]]{2})`
+	levelExp   = `level=(DEBUG-4|DEBUG|WARNING|NOTICE|INFO|WARN|ERROR|FATAL)`
+	regularExp = "^" + timeExp + " " + levelExp + " " + `msg=(.*)\n$`
+)
 
 func helperCommonTestCase(levelMsg slog.Level) []TestCase {
 	return []TestCase{
@@ -161,7 +165,7 @@ func TestError(t *testing.T) {
 
 func TestTraceNoError(t *testing.T) {
 	// https://regex101.com/
-	const regularExpTraceNoError = `^time=[[:digit:]]{4}\-[[:digit:]]{2}\-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg=(.*)\n$`
+	const regularExpTraceNoError = "^" + timeExp + " " + levelExp + " " + `msg=(.*)\n$`
 	b := bytes.Buffer{}
 	sh := slog.NewTextHandler(&b, &slog.HandlerOptions{
 		Level: LevelTrace,
@@ -179,7 +183,7 @@ func TestTraceNoError(t *testing.T) {
 
 func TestTraceError(t *testing.T) {
 	// https://regex101.com/
-	const regularExpTraceError = `^time=[[:digit:]]{4}\-[[:digit:]]{2}\-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg=(.*) error=(.*) query=\"(.*)\" elapsed=(.*) rows=(.*)\n$`
+	const regularExpTraceError = "^" + timeExp + " " + levelExp + " " + `msg=(.*) error=(.*) query=\"(.*)\" elapsed=(.*) rows=(.*)\n$`
 	b := bytes.Buffer{}
 	sh := slog.NewTextHandler(&b, &slog.HandlerOptions{
 		Level: LevelTrace,

--- a/internal/infrastructure/logger/init_test.go
+++ b/internal/infrastructure/logger/init_test.go
@@ -51,7 +51,7 @@ func TestLogBuildInfo(t *testing.T) {
 	slog.SetDefault(slogDefault)
 
 	// https://regex101.com/
-	const regularExp = `^time=[[:digit:]]{4}\-[[:digit:]]{2}\-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg=(.*)\n$`
+	const regularExp = "^" + timeExp + " " + levelExp + " " + `msg=(.*)\n$`
 
 	assert.Regexp(t, regularExp, b.String())
 }

--- a/internal/infrastructure/logger/middleware_test.go
+++ b/internal/infrastructure/logger/middleware_test.go
@@ -29,7 +29,7 @@ func TestMiddlewareLogValues(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// http://101regexp
-	regExp := `^time=[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg="(.*)" request-id="(.*)" method=(.*) uri="(.*)" status=(.*)\n$`
+	regExp := "^" + timeExp + " " + levelExp + " " + `msg="(.*)" request-id="(.*)" method=(.*) uri="(.*)" status=(.*)\n$`
 	require.Regexp(t, regExp, b.String())
 }
 
@@ -50,6 +50,6 @@ func TestMiddlewareLogValuesError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// http://101regexp
-	regExp := `^time=[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]+(|\+[[:digit:]]{2}:[[:digit:]]{2}) level=(.*) msg="(.*)" request-id="(.*)" method=(.*) uri="(.*)" status=(.*) err="(.*)"\n$`
+	regExp := "^" + timeExp + " " + levelExp + " " + `msg="(.*)" request-id="(.*)" method=(.*) uri="(.*)" status=(.*) err="(.*)"\n$`
 	require.Regexp(t, regExp, b.String())
 }


### PR DESCRIPTION
A wrong format in the regular expression was evoking to fail the unit tests related to the logs.